### PR TITLE
Add comprehensive documentation for core modules

### DIFF
--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -1,0 +1,121 @@
+# `dictionary.fypp`
+
+## Overview
+
+The `dictionary.fypp` file implements a generic dictionary type (`dictionary_t`) in Fortran. This dictionary is similar in concept to Python dictionaries or hash maps in other languages. It allows storing key-value pairs where keys are strings and values can be of any data type supported by the `variable_t` type from `variable.fypp`. This module provides the core functionality for creating, manipulating, and accessing data within these dictionaries.
+
+## Key Components
+
+### `dictionary_t`
+A derived type representing the dictionary. It internally uses a linked list of `dictionary_entry_t` to store key-value pairs.
+  - `first`: A pointer to the first `dictionary_entry_t` in the linked list.
+  - `len`: An integer storing the number of entries in the dictionary.
+
+### `dictionary_entry_t`
+A private derived type representing an entry in the dictionary.
+  - `key`: A character string (up to `DICTIONARY_KEY_LENGTH`) storing the key.
+  - `value`: A `variable_t` type storing the value associated with the key.
+  - `hash`: An integer storing the hash value of the key for efficient lookups.
+  - `next`: A pointer to the next `dictionary_entry_t` in the linked list.
+
+### Key Operations (Operators and Procedures)
+
+- **`LEN` (interface `len`)**: Returns the number of entries in the dictionary (using the internal counter).
+- **`LLEN` (interface `llen`)**: Returns the number of entries by traversing the linked list (actual count).
+- **`print`**: Prints all keys, their data types, and hash numbers to standard output.
+- **`operator(//)`**: Concatenates two dictionaries or extends a dictionary with new key-value pairs.
+- **`operator(.KEY.)`**: Returns the key of the current top entry in a dictionary (typically used in loops).
+- **`operator(.IN.)`**: Checks if a key exists in the dictionary.
+- **`operator(.NIN.)`**: Checks if a key does not exist in the dictionary.
+- **`operator(.VAL.)`**: Returns the value associated with a key (by copy).
+- **`operator(.VALP.)`**: Returns a pointer to the value associated with a key.
+- **`operator(.HASH.)` / `hash`**: Returns the hash value of the dictionary's first item's key.
+- **`operator(.EQ.)`**: Checks if two dictionaries have all the same keys (compares lengths and hash values of keys).
+- **`operator(.NE.)`**: Checks if two dictionaries do not share any common keys.
+- **`operator(.NEXT.)` / `next`**: Advances to the next entry in the dictionary (used for looping).
+- **`operator(.FIRST.)` / `first`**: Returns the first entry of a dictionary.
+- **`operator(.EMPTY.)` / `empty`**: Checks if the dictionary is empty or if a dictionary entry's value is empty.
+- **`hash_coll`**: Calculates the number of hash collisions in the dictionary.
+- **`delete`**: Deletes an entry by key or clears the entire dictionary.
+- **`pop`**: Removes an entry by key and returns its value.
+- **`copy`**: Creates a deep copy of a dictionary.
+- **`nullify`**: Nullifies a dictionary (clears all entries and releases memory) or nullifies a specific key.
+- **`extend`**: Extends a dictionary with entries from another dictionary (similar to `//` but as a subroutine).
+- **`which`**: Returns the data type string of the value associated with a key, or the first entry if no key is provided.
+- **`operator(.KV.)`**: Creates a dictionary entry by copying the value. Used like `'mykey'.KV.myvariable`.
+- **`operator(.KVP.)`**: Creates a dictionary entry by associating (pointing to) the value. Used like `'mykey'.KVP.my_target_variable`.
+- **`assign`**: Assigns a value from the dictionary to a variable (retrieves by copy).
+- **`associate`**: Associates a variable with a value in the dictionary (retrieves by pointer).
+
+## Important Variables/Constants
+
+### `DICTIONARY_KEY_LENGTH`
+An integer parameter defining the maximum character length for keys in the dictionary. Default is 48.
+
+### `DICTIONARY_NOT_FOUND`
+A character string parameter returned by some functions when a key is not found. Default is `'ERROR: key not found'`.
+
+### `HASH_ALGO`
+A preprocessor variable (defaulting to 0) that determines the hashing algorithm used.
+  - `0`: FNV-1a 32-bit hash algorithm.
+  - `-1`: A custom hash algorithm (notes indicate it has many collisions).
+
+## Usage Examples
+
+```fortran
+program test_dictionary
+  use dictionary
+  use variable
+  implicit none
+
+  type(dictionary_t) :: dict1, dict2, dict3
+  integer :: i_val
+  real, target :: r_val_target
+  real, pointer :: r_val_ptr
+
+  ! Create dictionary entries
+  dict1 = ('MeaningOfLife'.KV.42)
+  r_val_target = 3.14159
+  dict1 = dict1 // ('Pi'.KVP.r_val_target)
+
+  ! Check length
+  write(*,*) 'Length of dict1:', LEN(dict1) ! Output: Length of dict1: 2
+
+  ! Check if a key exists
+  if ('Pi' .IN. dict1) then
+    write(*,*) 'Pi exists in dict1'
+  end if
+
+  ! Get a value by copy
+  call assign(i_val, dict1, key='MeaningOfLife')
+  write(*,*) 'MeaningOfLife =', i_val ! Output: MeaningOfLife = 42
+
+  ! Get a value by pointer
+  call associate(r_val_ptr, dict1, key='Pi')
+  if (associated(r_val_ptr)) then
+    write(*,*) 'Pi (from pointer) =', r_val_ptr ! Output: Pi (from pointer) = 3.14159
+    r_val_target = 2.71828 ! Modify the original target
+    write(*,*) 'Pi (after modifying target) =', r_val_ptr ! Output: Pi (after modifying target) = 2.71828
+  end if
+
+  ! Print dictionary contents
+  call print(dict1)
+
+  ! Delete an entry
+  call delete(dict1, key='MeaningOfLife')
+  write(*,*) 'Length of dict1 after delete:', LEN(dict1) ! Output: Length of dict1 after delete: 1
+
+  ! Nullify the dictionary
+  call nullify(dict1)
+  write(*,*) 'Is dict1 empty after nullify?', .EMPTY. dict1 ! Output: Is dict1 empty after nullify? T
+
+end program test_dictionary
+```
+
+## Dependencies and Interactions
+
+- **`fdict_types`**: Uses type definitions from `fdict_types.fypp` (e.g., for precision of internal variables if any, though not explicitly shown for `dictionary_t` itself, it's a common dependency in the project).
+- **`variable`**: Heavily relies on `variable.fypp` for the `variable_t` type, which is used to store the actual values in the dictionary. This allows the dictionary to be generic and hold various data types.
+- **`fdict_common.fypp`**: This file includes `fdict_common.fypp`, which likely provides common preprocessor definitions and macros used within `dictionary.fypp`, such as `_pure`, `_elemental`, and `ALL_SHORTS_KINDS_TYPES_RANKS` for code generation.
+- **Hashing Algorithm**: The choice of `HASH_ALGO` affects the performance and collision rate of dictionary lookups.
+- **Memory Management**: Users must be careful with concatenated dictionaries. The documentation within the code suggests nullifying original dictionaries after concatenation to avoid issues (`d1 = d2 // d3; call nullify(d2); call nullify(d3)`). Also, when using `.KVP.` to store pointers, the pointed-to data must remain valid for the lifetime of its use in the dictionary.

--- a/docs/fdict_types.md
+++ b/docs/fdict_types.md
@@ -1,0 +1,78 @@
+# `fdict_types.fypp`
+
+## Overview
+
+The `fdict_types.fypp` file serves as a centralized module for defining various Fortran data type kinds. Its primary role is to ensure consistency in data representations, particularly for numerical precision (integers, reals) and logical types, across the fdict project. It leverages Fortran's intrinsic `iso_fortran_env` module where available and provides fallbacks using `selected_real_kind` and `selected_int_kind` for environments where `iso_fortran_env` might not be fully supported or for specific precision requirements not directly covered by it (e.g., `real80`).
+
+This module is crucial for writing portable and reliable Fortran code that behaves predictably across different compilers and hardware architectures by providing named constants for kind parameters.
+
+## Key Components
+
+This module primarily defines parameters for various data type kinds. These parameters are then used in declarations of variables throughout the fdict library.
+
+### Integer Kinds
+- `int8`: 8-bit integer (if `FDICT_WITH_INT8` is enabled).
+- `int16`: 16-bit integer (if `FDICT_WITH_INT16` is enabled).
+- `int32`: 32-bit integer.
+- `int64`: 64-bit integer.
+
+### Real Kinds
+- `real32`: Single-precision floating-point (approximately 6-7 decimal digits).
+- `real64`: Double-precision floating-point (approximately 15-17 decimal digits).
+- `real80`: Extended-precision floating-point (typically 80-bit, providing higher precision than `real64`, if `FDICT_WITH_REAL80` is enabled). Often corresponds to `selected_real_kind(18)`.
+- `real128`: Quadruple-precision floating-point (if `FDICT_WITH_REAL128` is enabled). Often corresponds to `selected_real_kind(30)`.
+
+### Logical Kinds
+- `log8`: 8-bit logical (if `FDICT_WITH_LOG8` is enabled). Typically maps to `int8`.
+- `log16`: 16-bit logical (if `FDICT_WITH_LOG16` is enabled). Typically maps to `int16`.
+- `log32`: 32-bit logical. Typically maps to `int32`.
+- `log64`: 64-bit logical (if `FDICT_WITH_LOG64` is enabled). Typically maps to `int64`.
+
+### ISO C Binding Kinds
+- If `FDICT_WITH_ISO_C` is enabled, this module also makes ISO C binding kinds like `c_ptr`, `c_funptr` available through `use, intrinsic :: iso_c_binding`.
+
+## Important Variables/Constants
+
+The "Key Components" section lists the primary constants defined in this file. These are all `integer, parameter` constants representing kind type parameters. Their availability and specific values can depend on preprocessor flags (`FDICT_WITH_...`) and the Fortran compiler's capabilities.
+
+- **`FDICT_WITH_ISO_ENV`**: Preprocessor flag. If true, types are sourced from `iso_fortran_env`. Otherwise, `selected_*_kind` is used.
+- **`FDICT_WITH_INT8`, `FDICT_WITH_INT16`**: Control inclusion of `int8`, `int16`.
+- **`FDICT_WITH_REAL80`, `FDICT_WITH_REAL128`**: Control inclusion of `real80`, `real128`.
+- **`FDICT_WITH_LOG8`, `FDICT_WITH_LOG16`, `FDICT_WITH_LOG64`**: Control inclusion of `log8`, `log16`, `log64`.
+- **`FDICT_WITH_ISO_C`**: Controls the use of `iso_c_binding` for C interoperability types.
+
+## Usage Examples
+
+```fortran
+module my_module
+  use fdict_types
+  implicit none
+
+  integer(kind=int32) :: my_standard_integer
+  real(kind=real64) :: my_double_precision_real
+  logical(kind=log8) :: my_small_logical
+
+  ! Check if extended precision is available before using it
+#:if FDICT_WITH_REAL80 == 1
+  real(kind=real80) :: my_extended_real
+#:else
+  ! Fallback or error if real80 is not available
+  real(kind=real64) :: my_extended_real ! Using real64 as fallback
+  ! write(*,*) "Warning: real80 not available, using real64 instead."
+#:endif
+
+  my_standard_integer = 12345
+  my_double_precision_real = 3.141592653589793_real64
+  my_small_logical = .true.
+
+  ! ... further code using these variables
+end module my_module
+```
+
+## Dependencies and Interactions
+
+- **`fdict_common.fypp`**: This file includes `fdict_common.fypp`. This inclusion is essential as `fdict_common.fypp` defines the preprocessor variables (e.g., `FDICT_WITH_ISO_ENV`, `FDICT_WITH_REAL80`) that control which type kinds are actually defined and how they are defined (either via `iso_fortran_env` or `selected_*_kind`).
+- **`iso_fortran_env` (Intrinsic Module)**: Conditionally used if `FDICT_WITH_ISO_ENV` is true. Provides standard kind parameters like `int32`, `int64`, `real32`, `real64`.
+- **`iso_c_binding` (Intrinsic Module)**: Conditionally used if `FDICT_WITH_ISO_C` is true. Provides types for C interoperability.
+- **Fortran Compiler**: The actual bit sizes and availability of certain kinds (especially `real80`, `real128`) depend on the capabilities of the Fortran compiler being used. This module attempts to provide a consistent way to access them.
+- **Other modules in fdict**: All other modules in the fdict library that declare variables with specific precision or type kinds (e.g., `variable.fypp`, `dictionary.fypp`) will `use fdict_types` to access these definitions. This ensures that the entire library uses a consistent set of type kinds.

--- a/docs/variable.md
+++ b/docs/variable.md
@@ -1,0 +1,122 @@
+# `variable.fypp`
+
+## Overview
+
+The `variable.fypp` file defines a powerful generic variable type (`variable_t`) in Fortran. This type is designed to hold data of almost any kind, including intrinsic Fortran types (integers, reals, complex, logicals, characters) of various precisions and ranks, as well as user-defined types (though support for user-defined types requires external routines).
+
+The `variable_t` acts as a container. It stores a pointer to the actual data and uses a type-transfer mechanism by encoding the data's type and pointer information into a character array (`enc`). This allows for dynamic typing capabilities within a statically-typed language like Fortran. This module is fundamental to `dictionary.fypp`, enabling its dictionaries to store heterogeneous data types.
+
+## Key Components
+
+### `variable_t`
+A derived type that serves as the generic data container.
+  - `t`: A character string (length `VARIABLE_TYPE_LENGTH`) that stores a short identifier for the data type being held (e.g., "r40" for a scalar single-precision real, "i81" for a 1D array of 64-bit integers).
+  - `enc`: An allocatable character array (`character(len=1), dimension(:)`) that stores the encoded representation of the pointer to the actual data.
+
+### Key Operations and Interfaces
+
+- **`which`**: Returns the type string (e.g., "r40", "i81") of the data stored in a `variable_t` or of a given Fortran variable.
+- **`delete`**: Deallocates the data pointed to by `variable_t` (if it's responsible for it) and resets the variable.
+- **`nullify`**: Resets the `variable_t` to an empty state, deallocating the `enc` array but not necessarily the data it points to (similar to Fortran's `nullify` for pointers).
+- **`empty`**: Checks if the `variable_t` is empty (i.e., not allocated or nullified).
+- **`print`**: Prints the type string of the `variable_t` to standard output.
+- **`associate_type`**: Allows associating a raw encoded character array (`enc`) with a `variable_t`, typically used for storing user-defined types where the encoding is handled externally.
+- **`enc`**: Retrieves the raw character encoding from a `variable_t`.
+- **`size_enc`**: Returns the size of the `enc` array.
+- **`cpack`**: Converts a `character(len=*)` string to a `character(len=1), dimension(:)` array.
+- **`cunpack`**: Converts a `character(len=1), dimension(:)` array back to a `character(len=*)` string.
+- **`assign`**:
+    - `assign(variable_out, variable_in)`: Copies the content from one `variable_t` to another (deep copy).
+    - `assign(variable_out, fortran_variable_in)`: Stores a copy of a Fortran variable into a `variable_t`.
+    - `assign(fortran_variable_out, variable_in)`: Retrieves a copy of the data from a `variable_t` into a Fortran variable.
+- **`associate`**:
+    - `associate(variable_out, variable_in)`: Makes one `variable_t` point to the same data as another `variable_t` (shallow copy of the descriptor).
+    - `associate(variable_out, fortran_target_in)`: Makes a `variable_t` point to a Fortran variable (which must have the `TARGET` attribute).
+    - `associate(fortran_pointer_out, variable_in)`: Makes a Fortran pointer point to the data held by a `variable_t`.
+- **`associatd`**: Checks if a `variable_t` is associated with a given Fortran pointer or if two `variable_t` instances are associated with the same data.
+
+## Important Variables/Constants
+
+### `VARIABLE_TYPE_LENGTH`
+An integer parameter defining the maximum length of the type specifier string (e.g., "r82", "c40") stored in `variable_t%t`. The value is automatically determined based on the maximum length of generated type names.
+
+### `VARIABLE_ENC_TYPE`
+A `character(len=1), dimension(1)` constant, likely used internally for `transfer` operations related to pointer encoding.
+
+### Preprocessor Macros for Type/Rank Combinations
+The file extensively uses `fypp` preprocessor loops (e.g., `#:for sh, k, t, minr, maxr in ALL_SHORTS_KINDS_TYPES_RANKS`) to generate specific `assign`, `associate`, `which`, and `associatd` procedures for a multitude of type, kind, and rank combinations. `ALL_SHORTS_KINDS_TYPES_RANKS` is defined in `fdict_common.fypp`.
+
+## Usage Examples
+
+```fortran
+program test_variable
+  use variable
+  use fdict_types
+  implicit none
+
+  type(variable_t) :: v1, v2
+  integer(kind=int32) :: i_scalar, i_array_1d(3)
+  real(kind=real64), target :: r_target_scalar
+  real(kind=real64), pointer :: r_ptr_scalar
+
+  ! Assign a scalar integer to v1
+  i_scalar = 123
+  call assign(v1, i_scalar)
+  write(*,*) 'v1 type:', which(v1) ! Output: v1 type: i40 (or similar for int32 scalar)
+
+  ! Retrieve the integer from v1
+  call assign(i_scalar, v1)
+  write(*,*) 'Retrieved i_scalar:', i_scalar ! Output: Retrieved i_scalar: 123
+
+  ! Assign a real array to v1
+  i_array_1d = [10, 20, 30]
+  call assign(v1, i_array_1d)
+  write(*,*) 'v1 type (array):', which(v1) ! Output: v1 type: i41 (or similar for int32 1D array)
+
+  ! Associate v1 with a real target
+  r_target_scalar = 3.14159_real64
+  call associate(v1, r_target_scalar)
+  write(*,*) 'v1 type (associated real):', which(v1) ! Output: v1 type: r80 (or similar)
+
+  ! Modify the target, v1 should reflect the change
+  r_target_scalar = 2.71828_real64
+  call associate(r_ptr_scalar, v1)
+  if (associated(r_ptr_scalar)) then
+    write(*,*) 'Associated r_ptr_scalar:', r_ptr_scalar ! Output: Associated r_ptr_scalar: 2.71828
+  end if
+
+  ! Assign v1 (pointing to r_target_scalar) to v2 (deep copy)
+  call assign(v2, v1)
+  ! Now modify r_target_scalar again. v2 should hold the value from before this change.
+  r_target_scalar = 1.61803_real64
+  call associate(r_ptr_scalar, v2)
+  if (associated(r_ptr_scalar)) then
+     ! This will print 2.71828 because v2 made a copy
+    write(*,*) 'Copied value in v2 (r_ptr_scalar):', r_ptr_scalar
+  end if
+  call associate(r_ptr_scalar, v1)
+  if (associated(r_ptr_scalar)) then
+    ! This will print 1.61803 because v1 is still associated
+    write(*,*) 'Original value in v1 (r_ptr_scalar):', r_ptr_scalar
+  end if
+
+
+  ! Clean up
+  call delete(v1)
+  call delete(v2)
+  write(*,*) 'v1 empty after delete?', empty(v1) ! Output: v1 empty after delete? T
+
+end program test_variable
+```
+
+## Dependencies and Interactions
+
+- **`fdict_types`**: Uses type kind definitions (e.g., `int32`, `real64`) from `fdict_types.fypp` for declaring internal pointers and for generating type-specific procedures.
+- **`fdict_common.fypp`**: Includes `fdict_common.fypp`, which provides common preprocessor definitions, macros (like `_pure`, `_elemental`), and importantly, the `ALL_SHORTS_KINDS_TYPES_RANKS` list that drives the generation of numerous type-specific procedures.
+- **Fortran Intrinsic `transfer`**: Relies heavily on the `transfer` intrinsic to convert pointer addresses and type information into the `enc` character array and back. This is a core mechanism for its type-erasure capability.
+- **Memory Management**:
+    - When `assign` is used to put data into `variable_t`, `variable_t` typically allocates its own memory and copies the data.
+    - When `associate` is used with a Fortran `TARGET` variable, `variable_t` stores a pointer to the existing variable. The user must ensure the `TARGET` variable remains allocated and valid as long as `variable_t` points to it.
+    - `delete` should be called on a `variable_t` to deallocate the data it owns.
+    - `nullify` makes the `variable_t` empty but doesn't deallocate the data if it was merely associated with an external target.
+- **`dictionary.fypp`**: The `dictionary_t` type in `dictionary.fypp` uses `variable_t` to store its values, allowing the dictionary to hold items of different data types.


### PR DESCRIPTION
This commit introduces Markdown documentation for the following key source files:
- `src/dictionary.fypp`: Implementation of a generic dictionary type.
- `src/fdict_types.fypp`: Definitions for various Fortran data type kinds.
- `src/variable.fypp`: Implementation of a generic variable type for holding any data.

The documentation for each file includes:
- An overview of the file's purpose.
- Descriptions of key components (types, functions, operators).
- Information on important variables and constants.
- Usage examples.
- Notes on dependencies and interactions with other modules.

A new `docs/` directory has been created to store these documentation files. This documentation aims to help developers understand, maintain, and extend the fdict library.